### PR TITLE
CD-141658 Support for specifying the path of the wkhtml binary

### DIFF
--- a/wkhtmltox/wkhtmltox.go
+++ b/wkhtmltox/wkhtmltox.go
@@ -186,9 +186,11 @@ type FetcherOptions struct {
 }
 
 type WKHtmlToX struct {
-	verbose  bool
-	timeout  time.Duration
-	fetchers map[string]fetcher.Fetcher
+	verbose              bool
+	timeout              time.Duration
+	fetchers             map[string]fetcher.Fetcher
+	WkhtmlToImageExePath string
+	WkhtmlToPdfExePath   string
 }
 
 func New(conf config.Configuration) (wkHtmlToX *WKHtmlToX, err error) {
@@ -258,10 +260,15 @@ func (p *WKHtmlToX) Convert(fetcherOpts FetcherOptions, convertOpts ConvertOptio
 	cmd := ""
 	ext := ""
 
+	if len(p.WkhtmlToImageExePath) == 0 || len(p.WkhtmlToPdfExePath) == 0 {
+		err = fmt.Errorf("Wkhtml executable path not found, please pass the exe path")
+		return
+	}
+
 	switch o := convertOpts.(type) {
 	case *ToImageOptions:
 		{
-			cmd = "wkhtmltoimage"
+			cmd = p.WkhtmlToImageExePath
 			ext = ".jpg"
 			if len(o.Format) > 0 {
 				ext = "." + o.Format
@@ -269,7 +276,7 @@ func (p *WKHtmlToX) Convert(fetcherOpts FetcherOptions, convertOpts ConvertOptio
 		}
 	case *ToPDFOptions:
 		{
-			cmd = "wkhtmltopdf"
+			cmd = p.WkhtmlToPdfExePath
 			ext = ".pdf"
 		}
 	default:
@@ -328,7 +335,7 @@ func (p *WKHtmlToX) Convert(fetcherOpts FetcherOptions, convertOpts ConvertOptio
 		return
 	}
 
-	defer os.Remove(tmpfileName)
+	defer os.RemoveAll(tmpDir)
 
 	var result []byte
 	result, err = ioutil.ReadFile(tmpfileName)


### PR DESCRIPTION
## JIRA

[JIRA Ticket](https://coupadev.atlassian.net/browse/CD-141658)
## Reviewers
 - [x] @saghaulor 
- [ ] @priyankatapar 
- [x] @sushmanivargi 

## Summary of Change

For supporting html conversion to pdf and image, we use wkhtmltopdf and wkhtmltoimage binary. library. The go library `go-wkhtmltox` is a wrapper on top of wkhtmlto* binary. The library does not support a way to specify the path of the wkhtmlto* binaries. Hence forking the repo [gogap/go-wkhtmltox](https://github.com/gogap/go-wkhtmltox) and making necessary changes to support for specifying the path.

