### PR TITLE
CD-191077 wktemp* files are not deleted and moved defer before return

### DIFF
--- a/wkhtmltox/wkhtmltox.go
+++ b/wkhtmltox/wkhtmltox.go
@@ -333,12 +333,12 @@ func (p *WKHtmlToX) Convert(fetcherOpts FetcherOptions, convertOpts ConvertOptio
 
 	ret, err1 := ioutil.ReadFile(tmpfileName)
 
+	defer removeWkhtmlTempFiles()
+	defer os.RemoveAll(tmpDir)
+
 	if err != nil && ret == nil {
 		return
 	}
-
-	defer removeWkhtmlTempFiles()
-	defer os.RemoveAll(tmpDir)
 
 	return ret, err1
 }
@@ -347,7 +347,7 @@ func (p *WKHtmlToX) Convert(fetcherOpts FetcherOptions, convertOpts ConvertOptio
 // Removing those temp files here.
 func removeWkhtmlTempFiles() error {
 	tmp := os.TempDir()
-	files, err := filepath.Glob(tmp + "wktemp-*")
+	files, err := filepath.Glob(tmp + "/wktemp-*")
 	if err != nil {
 		fmt.Println("Error in listing the wktemp-* files", err)
 		return nil


### PR DESCRIPTION
## JIRA

[Main JIRA](https://coupadev.atlassian.net/browse/CD-191077)

## Reviewers

- [ ] @priyankatapar 

## Summary of change

-  Changed the path for `wktemp*` files
-  Also moved the defer of removal of files before return 